### PR TITLE
クイズ画面のUI作成

### DIFF
--- a/lib/pages/quiz_page/components/quiz_body.dart
+++ b/lib/pages/quiz_page/components/quiz_body.dart
@@ -1,0 +1,39 @@
+import 'package:flutter/material.dart';
+import 'package:team_pampers/pages/quiz_page/components/quiz_select_widget.dart';
+
+class QuizPageBody extends StatelessWidget {
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children:[
+      Container(
+        margin: const EdgeInsets.all(10),
+        child: const Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            SizedBox(height: 150),
+            Text("Q1"),
+            SizedBox(height: 40),
+            Text("株式会社ゆめみはどの産業分野で事業を展開していますか？"),
+            Text("a) 飲食業"),
+            Text("b)インターネットサービス"),
+            Text("c)自転車製造"),
+            Text("d)建設業"),
+            SizedBox(height: 480),
+            Row(
+            mainAxisAlignment: MainAxisAlignment.spaceAround,
+              children: [
+                QuizSelectWidget(text: "A"),
+                QuizSelectWidget(text: "B"),
+                QuizSelectWidget(text: "C"),
+                QuizSelectWidget(text: "D"),
+              ],
+            )
+          ],
+        ),
+      ),
+      ]
+    );
+  }
+}

--- a/lib/pages/quiz_page/components/quiz_select_widget.dart
+++ b/lib/pages/quiz_page/components/quiz_select_widget.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/material.dart';
+import 'package:team_pampers/utils/utils.dart';
+
+class QuizSelectWidget extends StatelessWidget {
+  final String text;
+  const QuizSelectWidget({super.key, required this.text});
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      splashColor: Colors.blue,
+      child: Container(
+          decoration: BoxDecoration(
+            border: Border.all(color: Colors.black),
+          ),
+        height: context.deviceHeight*0.09,
+        width: context.deviceWidth*0.18,
+        child: Center(child: Text(text))
+      ),
+      onTap: () {},
+    );
+  }
+}

--- a/lib/pages/quiz_page/quiz_page.dart
+++ b/lib/pages/quiz_page/quiz_page.dart
@@ -1,0 +1,20 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+import 'components/quiz_body.dart';
+
+class QuizPage extends HookConsumerWidget {
+  const QuizPage({super.key});
+  static Route<dynamic> route() {
+    return MaterialPageRoute<dynamic>(
+      builder: (_) => const QuizPage(),
+    );
+  }
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return Scaffold(
+      body: QuizPageBody(),
+    );
+  }
+}


### PR DESCRIPTION
## 対応したこと
 - クイズ画面のUI作成

## 関連資料
## 残りタスク
クイズの判定ロジック
問題の作成
firestore連携
## 画面キャプチャ
![simulator_screenshot_CDD320C2-36A4-4580-A34C-149A0EA9D736](https://github.com/Issei-Hiramatsu/team_pampers/assets/91933942/4c16231c-ecbd-4c0b-8428-20505477ec7c)
